### PR TITLE
Workaround for running Kafka MPC in Scrapy Cloud

### DIFF
--- a/kafka_scanner/__init__.py
+++ b/kafka_scanner/__init__.py
@@ -551,6 +551,11 @@ class KafkaScannerSimple(KafkaScanner):
     """
     @retry(wait_fixed=60000, retry_on_exception=retry_on_exception)
     def _create_scan_consumer(self):
+        import sys, socket
+        if sys.version_info < (2, 7, 4):
+            # workaround for: http://bugs.python.org/issue6056
+            socket.setdefaulttimeout(None)
+
         self.consumer = kafka.SimpleConsumer(
             client=self._client,
             partitions=self._upper_offsets.keys(),

--- a/kafka_scanner/__init__.py
+++ b/kafka_scanner/__init__.py
@@ -30,6 +30,12 @@ logging.getLogger("kafka.client").setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
 
 
+import sys, socket
+if sys.version_info < (2, 7, 4):
+    # workaround for: http://bugs.python.org/issue6056
+    socket.setdefaulttimeout(None)
+
+
 class keydefaultdict(defaultdict):
     def __missing__(self, key):
         if self.default_factory is None:
@@ -551,11 +557,6 @@ class KafkaScannerSimple(KafkaScanner):
     """
     @retry(wait_fixed=60000, retry_on_exception=retry_on_exception)
     def _create_scan_consumer(self):
-        import sys, socket
-        if sys.version_info < (2, 7, 4):
-            # workaround for: http://bugs.python.org/issue6056
-            socket.setdefaulttimeout(None)
-
         self.consumer = kafka.SimpleConsumer(
             client=self._client,
             partitions=self._upper_offsets.keys(),


### PR DESCRIPTION
Recently Scrapy Cloud is setting a default timeout for all sockets, triggering the bug: http://bugs.python.org/issue6056 for Kafka MultiProcessConsumer.
The bug was fixed in CPython 2.7.4+.

This PR disables the default socket timeout when using Kafka Scanner in CPython < 2.7.4.

The bug should go away when using new CPython with kumo.